### PR TITLE
Consolidate calculator grid and form styles

### DIFF
--- a/app/components/calculadora/calculadora.scss
+++ b/app/components/calculadora/calculadora.scss
@@ -18,8 +18,8 @@
 /* ---------- Layout principal ------------------------------------- */
 .calc-grid {
   display: grid;
-  grid-template-columns: 1fr 12vw;
-  gap: 16px;
+  grid-template-columns: 1fr 340px;
+  gap: 28px;
   align-items: start;
 
   @media (max-width: 900px) {
@@ -29,12 +29,11 @@
 
 /* ---------- Formulario ------------------------------------------ */
 .calc-form {
-  padding: 20px;
-  border-radius: 30px;
+  background: #f3f3f4;
+  padding: 18px 20px;
+  border-radius: 22px;
 
   .field {
-    
-
     &.row {
       display: grid;
       grid-template-columns: 1fr 160px;
@@ -46,15 +45,18 @@
       font-size: 14px;
       color: $nardo;
     }
+  }
 
-    input[type='number'] {
-      width: 100%;
-      padding: 10px 12px;
-      border: 1px solid $nardo;
-      border-radius: 12px;
-      background: #fff;
-      font: $neue;
-    }
+  select,
+  input[type='number'] {
+    width: 100%;
+    background: #fff;
+    border: 1px solid $nardo;
+    border-radius: 28px;
+    padding: 12px 14px;
+    font-size: 15px;
+    font: $neue;
+    outline: none;
   }
 
   hr {
@@ -162,38 +164,6 @@
       gap: 8px;
       margin-top: 12px;
     }
-  }
-}
-
-
-
-
-/* Layout */
-.calc-grid {
-  grid-template-columns: 1fr 340px;
-  gap: 28px;
-}
-
-@media (max-width: 900px) {
-  .calc-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Caja izquierda */
-.calc-form {
-  background: #f3f3f4;
-  border-radius: 22px;
-  padding: 18px 20px;
-
-  select,
-  input[type='number'] {
-    background: #fff;
-    border: 1px solid $nardo;
-    border-radius: 28px;
-    padding: 12px 14px;
-    font-size: 15px;
-    outline: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- consolidate `.calc-grid` into one block and update final layout values
- merge duplicate `.calc-form` styles and apply unified field styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68910ce3b91083259e873d86428e5686