### PR TITLE
refactor: unify calc summary styles

### DIFF
--- a/app/components/calculadora/calculadora.scss
+++ b/app/components/calculadora/calculadora.scss
@@ -355,30 +355,6 @@
     }
   }
 }
-
-/* Resumen (sticky right) */
-.calc-summary .box {
-  border-radius: 18px;
-  border: 1px solid $nardo;
-  background: $nardo;
-  padding: 18px;
-}
-
-.calc-summary h4 {
-  margin: 0 0 8px;
-  font-size: 13px;
-  letter-spacing: .12em;
-  color: $gris-oscuro;
-  text-transform: uppercase;
-}
-
-.calc-summary .total {
-  font-size: 30px;
-  font-weight: 700;
-  color: $azul-ermo;
-  margin-bottom: 12px;
-}
-
 .btn {
   border-radius: 32px;
   padding: 12px 16px;


### PR DESCRIPTION
## Summary
- consolidate calc-summary styles into a single block
- remove redundant summary box declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68910ce340a483259b01ddf2c632b1f2