### PR TITLE
feat: use grid layout for calc blocks

### DIFF
--- a/app/components/calculadora/calculadora.scss
+++ b/app/components/calculadora/calculadora.scss
@@ -208,7 +208,7 @@
   }
 
   &__grid {
-    display: block;
+    display: grid;
     grid-template-columns: 1fr 380px;
     gap: 24px;
     align-items: center;


### PR DESCRIPTION
## Summary
- switch calculator blocks to CSS grid for proper column layout and spacing

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68910ce1c6408325b1b6837316d0a11e