### PR TITLE
Use StandardButton in calculator

### DIFF
--- a/app/buttons/standard-button.jsx
+++ b/app/buttons/standard-button.jsx
@@ -24,7 +24,8 @@ function StandardButton({
   hoverBg,
   hoverColor,
   borderColor,
-  hoverBorderColor,        
+  hoverBorderColor,
+  onClick,
 }) {
   const cssVars = {
     "--btn-bg": bg,
@@ -37,7 +38,7 @@ function StandardButton({
 
   return (
     <div className={`master_button ${style}`}>
-      <a href={link}>
+      <a href={link} onClick={onClick}>
         <div className="button" style={cssVars}>
           <p>{title}</p>
           <ArrowInButton />

--- a/app/components/calculadora/calculadora.jsx
+++ b/app/components/calculadora/calculadora.jsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 import "./calculadora.scss";
+import StandardButton from '@/app/buttons/standard-button';
 
 /* ---------- Config ---------- */
 const LS_KEY = 'calc-web-v1';
@@ -380,8 +381,15 @@ const handleDownloadPDF = async () => {
           <div className="total">{fmt(total)}</div>
 
           <div className="cta">
-            <button className="btn danger" type="button" onClick={handleDownloadPDF}>Descargar en PDF</button>
-            <a className="btn ghost" href="#contacto">Contactar</a>
+            <StandardButton
+              link="#"
+              title="Descargar en PDF"
+              onClick={(e) => {
+                e.preventDefault();
+                handleDownloadPDF();
+              }}
+            />
+            <StandardButton link="#contacto" title="Contactar" />
           </div>
         </div>
       </aside>

--- a/app/components/calculadora/calculadora.scss
+++ b/app/components/calculadora/calculadora.scss
@@ -394,19 +394,3 @@
   margin-bottom: 12px;
 }
 
-.btn {
-  border-radius: 32px;
-  padding: 12px 16px;
-}
-
-.btn.danger {
-  background: $amarillo-ermo;
-  border-color: $amarillo-ermo;
-  color: #fff;
-}
-
-.btn.ghost {
-  background: #f0f0f1;
-  color: #333;
-  border: 1.5px solid $azul-ermo;
-}


### PR DESCRIPTION
## Summary
- replace calculator CTA buttons with shared `StandardButton`
- allow `StandardButton` to receive `onClick` handlers
- drop unused `.btn` styles from calculator stylesheet

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68910beaf5108325b64e41a65ba29a7e