### PR TITLE
Show mobile calculator summary only within section

### DIFF
--- a/app/components/calculadora/calculadora.jsx
+++ b/app/components/calculadora/calculadora.jsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import StandardButton from '@/app/buttons/standard-button';
 import "./calculadora.scss";
 
@@ -81,6 +81,9 @@ export default function CalculadoraWeb() {
   const [paginas, setPaginas] = useState('1');
   const [complejidad, setComplejidad] = useState('basico');
 
+  const sectionRef = useRef(null);
+  const [showSummary, setShowSummary] = useState(false);
+
   // Estado de bloques
   const [accesibilidad, setAccesibilidad] = useState('incluido'); // 'incluido' | 'aa'
   const [seoTec, setSeoTec] = useState(false);
@@ -99,6 +102,16 @@ export default function CalculadoraWeb() {
   const [mantAnual, setMantAnual] = useState(false);
   const [mantHoras, setMantHoras] = useState(false);
   const [mantExternos, setMantExternos] = useState(false);
+
+  useEffect(() => {
+    const node = sectionRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => setShowSummary(entry.isIntersecting)
+    );
+    observer.observe(node);
+    return () => observer.unobserve(node);
+  }, []);
 
   // Cargar estado
   useEffect(() => {
@@ -237,7 +250,7 @@ const handleDownloadPDF = async () => {
 
 
   return (
-    <section className="calculadora__master calc-grid">
+    <section ref={sectionRef} className="calculadora__master calc-grid">
       {/* Columna izquierda */}
       <div className="calc-form">
         {/* TIPO DE PROYECTO */}
@@ -389,7 +402,7 @@ const handleDownloadPDF = async () => {
       </div>
 
       {/* Columna derecha (sticky) */}
-      <aside className="calc-summary">
+      <aside className={`calc-summary ${showSummary ? 'is-visible' : ''}`}>
         <div className="box">
           <h4>Resumen del<br></br>proyecto</h4>
           <div className="total">{fmt(total)}</div>

--- a/app/components/calculadora/calculadora.scss
+++ b/app/components/calculadora/calculadora.scss
@@ -109,6 +109,11 @@
     position: fixed;
     right: 1em;
     bottom: 1em;
+    display: none;
+
+    &.is-visible {
+      display: block;
+    }
   }
 
   .box {


### PR DESCRIPTION
## Summary
- Display calculator summary on mobile only when the section is in view using IntersectionObserver
- Hide summary by default on small screens and reveal with an `is-visible` class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891e1abb4ac83258ff5719c8956831a